### PR TITLE
tech: create a workflow to deploy on github page

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,48 @@
+name: Deploy
+
+on:
+  # Runs on pushes targeting tag
+  push:
+    tags:
+      - '*'
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: setup nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+
+      - name: Install dependencies
+        run: npm ci
+      - name: Build static content
+        run: npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the deployment of static content to GitHub Pages. The workflow is designed to streamline deployment processes and ensure consistency in production environments.

### GitHub Actions Workflow for Static Content Deployment:
* [`.github/workflows/static.yml`](diffhunk://#diff-33f2778a5bb1ccf0ce7a73eeeeb02daf6023c2bdb47ff841fcf782fc3e469404R1-R43): Added a new workflow named "Deploy static content to Pages," which triggers on pushes to the `main` branch or manual dispatch. It sets permissions for the `GITHUB_TOKEN`, ensures concurrency management for deployments, and defines a single deploy job to upload repository content and deploy it to GitHub Pages.