### PR TITLE
tech: create workflow to deploy release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+            node-version: 'latest'
+            cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build project
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          commit_message: 'Deploy to GitHub Pages: ${{ github.sha }}'


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate deployment to GitHub Pages whenever a new tag is pushed or the workflow is manually triggered. The workflow handles checking out the code, setting up Node.js, installing dependencies, building the project, and deploying the output to the `gh-pages` branch.

**CI/CD automation:**

* Added `.github/workflows/release.yml` to automate building and deploying the project to GitHub Pages on tag push or manual trigger, using Node.js and the `peaceiris/actions-gh-pages` action.