### PR TITLE
tech: add workflow to merge pr

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,43 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+  check_suite:
+    types:
+      - completed
+    status:
+      - success
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  auto_merge:
+    if: |
+      github.event_name == 'pull_request' &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'Ready to merge') &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.SERVICE_TOKEN }}
+
+      - name: Rebase, enable auto-merge or merge pull request
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.SERVICE_TOKEN }}
+        run: |
+          gh pr update-branch $PR_NUMBER --rebase
+          gh pr merge $PR_NUMBER --auto -s -d


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the merging of pull requests that meet specific criteria. The workflow is triggered by various pull request events and ensures that only non-draft pull requests labeled "Ready to merge" on the `main` branch are considered. The workflow performs a rebase and enables auto-merge using the GitHub CLI.

Automation enhancements:

* Added `.github/workflows/auto-merge.yml` to define a workflow that automatically rebases and merges pull requests labeled "Ready to merge" when certain events occur, streamlining the merge process for the `main` branch.